### PR TITLE
URISyntaxException when using printer url with URI encoded whitespaces

### DIFF
--- a/src/main/kotlin/de/gmuth/ipp/client/IppClient.kt
+++ b/src/main/kotlin/de/gmuth/ipp/client/IppClient.kt
@@ -113,7 +113,7 @@ open class IppClient(
     fun toHttpUri(ippUri: URI) = with(ippUri) {
         val scheme = scheme.replace("ipp", "http")
         val port = if (port == -1) 631 else port
-        URI.create("$scheme://$host:$port$path")
+        URI.create("$scheme://$host:$port$rawPath")
     }
 
     fun httpPostRequest(httpUri: URI, request: IppRequest) = httpClient.post(

--- a/src/test/kotlin/de/gmuth/ipp/client/IppClientTests.kt
+++ b/src/test/kotlin/de/gmuth/ipp/client/IppClientTests.kt
@@ -1,0 +1,28 @@
+package de.gmuth.ipp.client
+
+import de.gmuth.http.HttpClientMock
+import de.gmuth.ipp.core.IppOperation.GetPrinterAttributes
+import de.gmuth.ipp.core.IppResponse
+import de.gmuth.ipp.core.IppStatus.SuccessfulOk
+import de.gmuth.log.Logging
+import org.junit.Test
+import java.net.URI
+
+class IppClientTests {
+    companion object {
+        val log = Logging.getLogger { }
+    }
+
+    val httpClient = HttpClientMock()
+    val ippClient = IppClient(httpClient = httpClient)
+
+    init {
+        httpClient.ippResponse = IppResponse(SuccessfulOk)
+    }
+
+    @Test
+    fun sendRequestToURIWithEncodedWhitespaces() {
+        val request = ippClient.ippRequest(GetPrinterAttributes, URI.create("ipp://localhost/printers/PDF%20Printer"))
+        ippClient.exchange(request)
+    }
+}


### PR DESCRIPTION
When trying to connect to a ipp printer whose URI contains encoded whitespaces,  e.g `http://localhost/PDF%20Printer/.printer`, the library throws an URISyntaxException when trying to sent the ipp request. 
This is due to the `IPPClient`s method `toHttpUri` using the `getPath` from `java.net.URI` which delivers the decoded path version. As a following result the call of `URI.create("$scheme://$host:$port$path")` throws the afformentioned exception.

As a solution we should use the `java.net.URI::getRawPath`
Fixes #13 