### PR TITLE
Add redirect location to exception message

### DIFF
--- a/src/main/kotlin/de/gmuth/ipp/client/IppClient.kt
+++ b/src/main/kotlin/de/gmuth/ipp/client/IppClient.kt
@@ -170,6 +170,10 @@ open class IppClient(val config: IppConfig = IppConfig()) {
 
         responseCode == 401 -> with(request) { "Not authorized for operation $operation on $printerOrJobUri (userName required)" }
         responseCode == 426 -> "HTTP status $responseCode, $responseMessage, Try ipps://${request.printerOrJobUri.host}"
+        responseCode in 300..399 -> {
+            val locationHeader = headerFields["Location"] ?: headerFields["location"]
+            "HTTP redirect: $responseCode, $responseMessage redirect-location: $locationHeader"
+        }
         responseCode != 200 -> "HTTP request failed: $responseCode, $responseMessage"
         contentType != null && !contentType.startsWith(APPLICATION_IPP) -> "Invalid Content-Type: $contentType"
         exception != null -> exception.message


### PR DESCRIPTION
Hi @gmuth ,

thanks for providing this really nice library.
Today I faced an issue when I tried to print when the printer returned a `307, Temporary Redirect`.

I know I could simply catch the `HttpPostException` and extract the header myself, which I gonna do now, but IMHO it would be convenient to have the desired location already as part of the message.

Please let me know what you think.