### PR TITLE
Update kotlin-stdlib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 // gradle 8? should be done when moved to kotlin.jvm plugin 1.9.x (to remove deprecation warnings)
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.7.22" // https://kotlinlang.org/docs/gradle-configure-project.html
+    id("org.jetbrains.kotlin.jvm") version "2.3.20" // https://kotlinlang.org/docs/gradle-configure-project.html
     id("org.jetbrains.dokka") version "1.7.20"      // https://kotlinlang.org/docs/dokka-get-started.html
     id("org.sonarqube") version "5.0.0.4638"        // https://plugins.gradle.org/plugin/org.sonarqube
     //id("org.sonarqube") version "3.5.0.2730"      // supports java 8, dropped with 4.1

--- a/src/main/kotlin/de/gmuth/ipp/core/IppInputStream.kt
+++ b/src/main/kotlin/de/gmuth/ipp/core/IppInputStream.kt
@@ -115,7 +115,7 @@ class IppInputStream(inputStream: BufferedInputStream) : DataInputStream(inputSt
         }
 
         Charset -> {
-            Charset.forName(readString())
+            java.nio.charset.Charset.forName(readString())
         }
 
         Uri -> {


### PR DESCRIPTION
Our Dependency-Scanner complained because of [CVE-2020-29582](https://nvd.nist.gov/vuln/detail/CVE-2020-29582). Could you please update the dependency kotlin-stdlib? If I understand the CVE correctly, we need at least version 2.1 for the vulnerability to be fixed.

I've attached the following PR. However, I have to admit that I have next to no experience with kotlin. I would appreciate a review.